### PR TITLE
Add get-all-admin endpoint

### DIFF
--- a/controllers/patient_handler.go
+++ b/controllers/patient_handler.go
@@ -32,6 +32,7 @@ func NewPatientHandler(e *gin.Engine, us entities.PatientUseCase) {
 	e.POST("/patient", handler.InsertPatient)
 	e.DELETE("/patient/:id", handler.DeletePatientByID)
 	e.PATCH("/patient/:id", handler.UpdatePatientByID)
+	e.GET("/get-all-admin", handler.GetAllAdmin)
 }
 
 func (p *PatientHandler) GetPatientByID(c *gin.Context) {
@@ -119,6 +120,18 @@ func (p *PatientHandler) UpdatePatientByID(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, id)
+}
+
+func (p *PatientHandler) GetAllAdmin(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	adminlist, err := p.AUsecase.GetAllAdmin(ctx)
+	if err != nil {
+		c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, adminlist)
 }
 
 func getStatusCode(err error) int {

--- a/entities/partadmin.go
+++ b/entities/partadmin.go
@@ -1,0 +1,32 @@
+package entities
+
+import (
+	"fmt"
+	"time"
+)
+
+type PartAdmin struct {
+	ID        int32      `json:"id" binding:"-"`
+	Name      *string    `json:"name" binding:"required"`
+	KhmerName *string    `json:"khmerName" binding:"required"`
+	Dob       *time.Time `json:"dob" binding:"required"`
+	Gender    *string    `json:"gender" binding:"required"`
+	ContactNo *string    `json:"contactNo" binding:"required"`
+}
+
+// TableName specifies the table name for the PartAdmin model.
+func (PartAdmin) TableName() string {
+	return "partadmin"
+}
+
+// ToString generates a simple string representation of the PartAdmin struct.
+func (pa PartAdmin) String() string {
+	result := fmt.Sprintf("\nADMIN\n")
+	result += fmt.Sprintf("ID: %d\n", pa.ID)
+	result += fmt.Sprintf("Name: %s\n", *pa.Name)
+	result += fmt.Sprintf("KhmerName: %s\n", *pa.KhmerName)
+	result += fmt.Sprintf("Dob: %s\n", pa.Dob.Format("2006-01-02"))
+	result += fmt.Sprintf("Gender: %s\n", *pa.Gender)
+	result += fmt.Sprintf("ContactNo: %s\n", *pa.ContactNo)
+	return result
+}

--- a/entities/patient.go
+++ b/entities/patient.go
@@ -20,6 +20,7 @@ type PatientUseCase interface {
 	DeletePatientByID(ctx context.Context, id int32) (int32, error) // Deletes a Patient by ID
 	UpdatePatientByID(ctx context.Context, id int32, patient *Patient) (int32, error)
 	InsertPatient(ctx context.Context, patient *Patient) (int32, error) // Creates a new patient and inserts in database
+	GetAllAdmin(ctx context.Context) ([]PartAdmin, error)
 }
 
 type PatientRepository interface {
@@ -27,4 +28,5 @@ type PatientRepository interface {
 	DeletePatientByID(ctx context.Context, id int32) (int32, error) // Deletes a Patient by ID
 	UpdatePatientByID(ctx context.Context, id int32, patient *Patient) (int32, error)
 	InsertPatient(ctx context.Context, patient *Patient) (int32, error) // Creates a new patient and inserts in database
+	GetAllAdmin(ctx context.Context) ([]PartAdmin, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.0
 
 require (
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-playground/validator/v10 v10.20.0
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/lib/pq v1.10.9
 	github.com/ory/dockertest/v3 v3.10.0
@@ -31,7 +32,6 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/repository/postgres/postgres_patient.go
+++ b/repository/postgres/postgres_patient.go
@@ -521,3 +521,27 @@ func (p *postgresPatientRepository) UpdatePatientByID(ctx context.Context, id in
 	}
 	return id, nil
 }
+
+func (p *postgresPatientRepository) GetAllAdmin(ctx context.Context) ([]entities.PartAdmin, error) {
+	var rows *sql.Rows
+	result := make([]entities.PartAdmin, 0)
+	query := "SELECT id, name, khmer_name, dob, gender, contact_no FROM ADMIN"
+	rows, err := p.Conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		partadmin := entities.PartAdmin{}
+		err = rows.Scan(&partadmin.ID, &partadmin.Name, &partadmin.KhmerName, &partadmin.Dob, &partadmin.Gender, &partadmin.ContactNo)
+
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, partadmin)
+	}
+
+	return result, nil
+}

--- a/repository/postgres/postgres_patient_test.go
+++ b/repository/postgres/postgres_patient_test.go
@@ -472,3 +472,16 @@ func TestFull(t *testing.T) {
 	assert.Equal(t, updatedAdmin.Age, updatedPatient6.Admin.Age)
 	assert.Equal(t, updatedAdmin.Gender, updatedPatient6.Admin.Gender)
 }
+
+func TestGetAllAdmin(t *testing.T) {
+	repo := NewPostgresPatientRepository(db)
+
+	patient_repo, ok := repo.(*postgresPatientRepository)
+	if !ok {
+		log.Fatal("Failed to assert repo")
+	}
+
+	admins, err := patient_repo.GetAllAdmin(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, admins)
+}

--- a/usecases/patient_ucase.go
+++ b/usecases/patient_ucase.go
@@ -47,9 +47,9 @@ func (p patientUsecase) UpdatePatientByID(ctx context.Context, id int32, patient
 	return p.patientRepo.UpdatePatientByID(ctx, id, patient)
 }
 
-//func (p patientUsecase) GetAllFromAdmin(ctx context.Context) ([]entities.Admin, error) {
-//	ctx, cancel := context.WithTimeout(ctx, p.contextTimeout)
-//	defer cancel()
-//
-//	return p.patientRepo.GetAllFromAdmin(ctx)
-//}
+func (p patientUsecase) GetAllAdmin(ctx context.Context) ([]entities.PartAdmin, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.contextTimeout)
+	defer cancel()
+
+	return p.patientRepo.GetAllAdmin(ctx)
+}


### PR DESCRIPTION
Client side will need to efficiently get all the admin data of the patients to render in the View / Search Patients page.

This endpoint enables getting all the patient admin category data, which can then be cached and stored on the client-side for rendering.