### PR TITLE
Add Search Patients feature

### DIFF
--- a/controllers/patient_handler.go
+++ b/controllers/patient_handler.go
@@ -33,6 +33,7 @@ func NewPatientHandler(e *gin.Engine, us entities.PatientUseCase) {
 	e.DELETE("/patient/:id", handler.DeletePatientByID)
 	e.PATCH("/patient/:id", handler.UpdatePatientByID)
 	e.GET("/get-all-admin", handler.GetAllAdmin)
+	e.GET("/search-patients/:search-name", handler.SearchPatients)
 }
 
 func (p *PatientHandler) GetPatientByID(c *gin.Context) {
@@ -132,6 +133,20 @@ func (p *PatientHandler) GetAllAdmin(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, adminlist)
+}
+
+func (p *PatientHandler) SearchPatients(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	patientName := c.Param("search-name")
+
+	foundPatients, err := p.AUsecase.SearchPatients(ctx, patientName)
+	if err != nil {
+		c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, foundPatients)
 }
 
 func getStatusCode(err error) int {

--- a/entities/patient.go
+++ b/entities/patient.go
@@ -21,6 +21,7 @@ type PatientUseCase interface {
 	UpdatePatientByID(ctx context.Context, id int32, patient *Patient) (int32, error)
 	InsertPatient(ctx context.Context, patient *Patient) (int32, error) // Creates a new patient and inserts in database
 	GetAllAdmin(ctx context.Context) ([]PartAdmin, error)
+	SearchPatients(ctx context.Context, search string) ([]PartAdmin, error)
 }
 
 type PatientRepository interface {
@@ -29,4 +30,5 @@ type PatientRepository interface {
 	UpdatePatientByID(ctx context.Context, id int32, patient *Patient) (int32, error)
 	InsertPatient(ctx context.Context, patient *Patient) (int32, error) // Creates a new patient and inserts in database
 	GetAllAdmin(ctx context.Context) ([]PartAdmin, error)
+	SearchPatients(ctx context.Context, search string) ([]PartAdmin, error)
 }

--- a/repository/postgres/postgres_patient.go
+++ b/repository/postgres/postgres_patient.go
@@ -545,3 +545,30 @@ func (p *postgresPatientRepository) GetAllAdmin(ctx context.Context) ([]entities
 
 	return result, nil
 }
+
+func (p *postgresPatientRepository) SearchPatients(ctx context.Context, search string) ([]entities.PartAdmin, error) {
+	var rows *sql.Rows
+	result := make([]entities.PartAdmin, 0)
+
+	rows, err := p.Conn.QueryContext(ctx, `
+				SELECT id, name, khmer_name, dob, gender, contact_no 
+				FROM ADMIN 
+				WHERE LOWER(name) = LOWER($1) OR LOWER(khmer_name) = LOWER($2)`, search, search)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		partadmin := entities.PartAdmin{}
+		err = rows.Scan(&partadmin.ID, &partadmin.Name, &partadmin.KhmerName, &partadmin.Dob, &partadmin.Gender, &partadmin.ContactNo)
+
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, partadmin)
+	}
+
+	return result, nil
+}

--- a/repository/postgres/postgres_patient_test.go
+++ b/repository/postgres/postgres_patient_test.go
@@ -485,3 +485,16 @@ func TestGetAllAdmin(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, admins)
 }
+
+func TestPostgresPatientRepository_SearchPatients(t *testing.T) {
+	repo := NewPostgresPatientRepository(db)
+
+	patient_repo, ok := repo.(*postgresPatientRepository)
+	if !ok {
+		log.Fatal("Failed to assert repo")
+	}
+
+	admins, err := patient_repo.SearchPatients(context.Background(), "១២៣៤ ៥៦៧៨៩០ឥឲ")
+	assert.Nil(t, err)
+	assert.NotNil(t, admins)
+}

--- a/usecases/patient_ucase.go
+++ b/usecases/patient_ucase.go
@@ -53,3 +53,10 @@ func (p patientUsecase) GetAllAdmin(ctx context.Context) ([]entities.PartAdmin, 
 
 	return p.patientRepo.GetAllAdmin(ctx)
 }
+
+func (p patientUsecase) SearchPatients(ctx context.Context, search string) ([]entities.PartAdmin, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.contextTimeout)
+	defer cancel()
+
+	return p.patientRepo.SearchPatients(ctx, search)
+}


### PR DESCRIPTION
Resolves #14 

We want to be able to search for patients by their name or khmer name. This endpoint enables getting an array of the admin category data of all patients matching the name or khmer name being searched, and is case insensitive.