### PR TITLE
Add Token Validation Route

### DIFF
--- a/controllers/login_handler.go
+++ b/controllers/login_handler.go
@@ -19,7 +19,7 @@ func NewLoginHandler(e *gin.Engine, us entities.LoginUseCase) {
 		Usecase: us,
 	}
 	e.POST("/login", handler.Login)
-	e.GET("/login/isValidToken", middleware.AuthRequired(), handler.IsValidToken)
+	e.GET("/login/is-valid-token", middleware.AuthRequired(), handler.IsValidToken)
 }
 
 func (l *LoginHandler) Login(c *gin.Context) {

--- a/controllers/login_handler.go
+++ b/controllers/login_handler.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/jieqiboh/sothea_backend/controllers/middleware"
 	"github.com/jieqiboh/sothea_backend/entities"
 	"net/http"
 )
@@ -18,6 +19,7 @@ func NewLoginHandler(e *gin.Engine, us entities.LoginUseCase) {
 		Usecase: us,
 	}
 	e.POST("/login", handler.Login)
+	e.GET("/login/isValidToken", middleware.AuthRequired(), handler.IsValidToken)
 }
 
 func (l *LoginHandler) Login(c *gin.Context) {
@@ -25,10 +27,8 @@ func (l *LoginHandler) Login(c *gin.Context) {
 	var u entities.User
 	if err := c.ShouldBindJSON(&u); err != nil {
 		// Use type assertion to check if err is of type validator.ValidationErrors
-		if validationErrs, ok := err.(validator.ValidationErrors); ok {
-			// Get the first Validation Error
-			fieldErr := validationErrs[0]
-			c.JSON(http.StatusBadRequest, gin.H{"error": fieldErr.Error()})
+		if _, ok := err.(validator.ValidationErrors); ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Username or password must be a non-empty string!"})
 			return // exit on first error
 		} else {
 			// Handle other types of errors (e.g., JSON binding errors)
@@ -45,5 +45,10 @@ func (l *LoginHandler) Login(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"token": tokenString})
+	return
+}
+
+func (l *LoginHandler) IsValidToken(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"message": "Valid Token"})
 	return
 }

--- a/controllers/middleware/auth.go
+++ b/controllers/middleware/auth.go
@@ -17,7 +17,7 @@ func CreateToken(username string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256,
 		jwt.MapClaims{
 			"username": username,
-			"exp":      time.Now().Add(time.Hour * 12).Unix(),
+			"exp":      time.Now().Add(time.Second * 10).Unix(),
 		})
 	tokenString, err := token.SignedString(secretKey)
 	if err != nil {


### PR DESCRIPTION
Add a route to perform simple token validation so that the frontend can use it to ensure user is still authenticated when navigating between pages.