### PR TITLE
Add support for patient db export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ ENV POSTGRES_DB=patients
 
 # Copy the initialization scripts into the Docker entrypoint directory
 COPY ./sql /docker-entrypoint-initdb.d
-#COPY sql/patients_setup.sql /docker-entrypoint-initdb.d/init.sql
 
 # Expose the PostgreSQL port
 EXPOSE 5432
+
+# Create a volume mount point
+VOLUME ["/tmp"]
 
 # Set the entrypoint to the default PostgreSQL entrypoint
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To facilitate easy setup of the patients database with preloaded data, we've opt
 
 2. Build the Docker image for the Postgres database: `docker build -t sothea-db .`
 
-3. Run the Postgres database container with `docker run --rm --name sothea-db -d -p 5432:5432 sothea-db`
+3. Run the Postgres database container with `docker run --rm --name sothea-db -d -p 5432:5432 -v $(pwd)/tmp:/tmp sothea-db`
 
 4. To stop the container, run `docker stop sothea-db`
 

--- a/controllers/patient_handler_test.go
+++ b/controllers/patient_handler_test.go
@@ -115,6 +115,7 @@ func newTestPatientHandler(e *gin.Engine, us entities.PatientUseCase) {
 	e.PATCH("/patient/:id", handler.UpdatePatientByID)
 	e.GET("/get-all-admin", handler.GetAllAdmin)
 	e.GET("/search-patients/:search-name", handler.SearchPatients)
+	e.GET("/export-db", handler.ExportDatabaseToCSV)
 }
 
 // Success - 200 OK
@@ -362,3 +363,22 @@ func TestSearchPatients_Success(t *testing.T) {
 
 	assert.Equal(t, 200, w.Code)
 }
+
+// Success - 200 OK
+//func TestExportDatabaseToCSV_Success(t *testing.T) {
+//	var mockUsecase mocks.PatientUseCase
+//	mockUsecase.On("ExportDatabaseToCSV", context.Background()).Return(nil)
+//	router := gin.Default()
+//	newTestPatientHandler(router, &mockUsecase)
+//
+//	w := httptest.NewRecorder()
+//	req, _ := http.NewRequest("GET", "/export-db", nil)
+//
+//	router.ServeHTTP(w, req)
+//
+//	if w.Code != http.StatusOK {
+//		t.Fatalf("Expected status code 200, but got %d. Response body: %s", w.Code, w.Body.String())
+//	}
+//
+//	assert.Equal(t, 200, w.Code)
+//}

--- a/entities/patient.go
+++ b/entities/patient.go
@@ -22,6 +22,7 @@ type PatientUseCase interface {
 	InsertPatient(ctx context.Context, patient *Patient) (int32, error) // Creates a new patient and inserts in database
 	GetAllAdmin(ctx context.Context) ([]PartAdmin, error)
 	SearchPatients(ctx context.Context, search string) ([]PartAdmin, error)
+	ExportDatabaseToCSV(ctx context.Context) error
 }
 
 type PatientRepository interface {
@@ -31,4 +32,5 @@ type PatientRepository interface {
 	InsertPatient(ctx context.Context, patient *Patient) (int32, error) // Creates a new patient and inserts in database
 	GetAllAdmin(ctx context.Context) ([]PartAdmin, error)
 	SearchPatients(ctx context.Context, search string) ([]PartAdmin, error)
+	ExportDatabaseToCSV(ctx context.Context) error
 }

--- a/main.go
+++ b/main.go
@@ -61,10 +61,6 @@ func main() {
 		log.Fatal("Database connection failed:", err)
 	}
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	defer func() {
 		err := db.Close()
 		if err != nil {

--- a/mocks/PatientRepository.go
+++ b/mocks/PatientRepository.go
@@ -42,6 +42,24 @@ func (_m *PatientRepository) DeletePatientByID(ctx context.Context, id int32) (i
 	return r0, r1
 }
 
+// ExportDatabaseToCSV provides a mock function with given fields: ctx
+func (_m *PatientRepository) ExportDatabaseToCSV(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExportDatabaseToCSV")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetAllAdmin provides a mock function with given fields: ctx
 func (_m *PatientRepository) GetAllAdmin(ctx context.Context) ([]entities.PartAdmin, error) {
 	ret := _m.Called(ctx)

--- a/mocks/PatientUseCase.go
+++ b/mocks/PatientUseCase.go
@@ -42,6 +42,24 @@ func (_m *PatientUseCase) DeletePatientByID(ctx context.Context, id int32) (int3
 	return r0, r1
 }
 
+// ExportDatabaseToCSV provides a mock function with given fields: ctx
+func (_m *PatientUseCase) ExportDatabaseToCSV(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExportDatabaseToCSV")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetAllAdmin provides a mock function with given fields: ctx
 func (_m *PatientUseCase) GetAllAdmin(ctx context.Context) ([]entities.PartAdmin, error) {
 	ret := _m.Called(ctx)

--- a/usecases/patient_ucase.go
+++ b/usecases/patient_ucase.go
@@ -60,3 +60,10 @@ func (p *patientUsecase) SearchPatients(ctx context.Context, search string) ([]e
 
 	return p.patientRepo.SearchPatients(ctx, search)
 }
+
+func (p *patientUsecase) ExportDatabaseToCSV(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, p.contextTimeout)
+	defer cancel()
+
+	return p.patientRepo.ExportDatabaseToCSV(ctx)
+}


### PR DESCRIPTION
Patient database is exported as a CSV file and stored in the docker container in /tmp/output.csv, which is also mounted on a local volume in /tmp in the project root.